### PR TITLE
Open GitHub / Discord links in a new tab

### DIFF
--- a/src/components/AddonModal.js
+++ b/src/components/AddonModal.js
@@ -131,7 +131,7 @@ function AddonModal({ addon, onHide }) {
                     if ((key === "github" && typeof addon.links.download === "undefined") || key === "download") return <></>
                     else {
                         return <Tooltiped key={key} tooltip={key}>
-                            <a href={addon.links[key]}>{getIcon(key)}</a>
+                            <a href={addon.links[key]} target="_blank">{getIcon(key)}</a>
                         </Tooltiped>
                     }
                 })}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Instead of opening the GitHub or Discord link in the **current** tab, this will open the link in a **new** tab.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you plan to continue to browse the website this will open the GitHub repo in a new tab. This could be useful if a user is searching for plugins or browsing every page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. I created my own Gatsby Cloud website to make sure my changes work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?
