### PR TITLE
Fix that some addons are not detected

### DIFF
--- a/addons.py
+++ b/addons.py
@@ -51,7 +51,7 @@ while incomplete:
                 repo = file['repository']
                 if not repo['private']:
                     repos.add(repo['full_name'])
-            incomplete = r["incomplete_results"]
+            incomplete = len(r["items"]) != 0
             break
         except Exception:
             print("[search fetch] error. ignoring...")
@@ -78,7 +78,7 @@ while incomplete:
                 repo = file['repository']
                 if not repo['private']:
                     repos.add(repo['full_name'])
-            incomplete = r["incomplete_results"]
+            incomplete = len(r["items"]) != 0
             break
         except Exception:
             print("[search fetch] error. ignoring...")


### PR DESCRIPTION
## Description
I don't know why but `incomplete_results` is always false. So only the first page is fetched
This PR fix that, the amount of unverified addons should increase from 140 to 239

## How Has This Been Tested?
By running the python script on my computer and seeing the result

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] Have you successfully ran tests with your changes locally?
